### PR TITLE
READMEに資料へのリンクがほしい

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Reference
  * [HTTP/1.1: Header Field Definitions #14.4 Accept-Language](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4)
  * [RFC 4647 - Matching of Language Tags](http://tools.ietf.org/html/rfc4647)
  * [RFC 5646 - Tags for Identifying Languages](http://tools.ietf.org/html/rfc5646)
+ * [Accept-language - Slideshare](http://www.slideshare.net/tadsan/accept-language)
+ * [Accept-Languageの実装例 - Qita](http://qiita.com/tadsan/items/24cf40f067295df2ffb8)
 
 Copyright
 ---------


### PR DESCRIPTION
現状のReference
''''
HTTP/1.1: Header Field Definitions #14.4 Accept-Language
RFC 4647 - Matching of Language Tags
RFC 5646 - Tags for Identifying Languages
''''

現状のREADMEにはコードの利点や使い方などの情報が不足していると思いました。

検索したらスライド資料やqitaがありました。
コードの概要や例が載っていたので、参考になると思います。
http://www.slideshare.net/tadsan/accept-language
http://qiita.com/tadsan/items/24cf40f067295df2ffb8

下記をReferenceに追加
''''
[Accept-language - Slideshare](http://www.slideshare.net/tadsan/accept-language)
[Accept-Languageの実装例 - Qita](http://qiita.com/tadsan/items/24cf40f067295df2ffb8)
''''

READMEにリンクがあるとわかりやすいと思いました。
