### PR TITLE
Fix deprecated warning on PHP 8.2: `Use of "self" in callables is deprecated`

### DIFF
--- a/src/AcceptLanguage.php
+++ b/src/AcceptLanguage.php
@@ -60,7 +60,7 @@ class AcceptLanguage
      */
     public static function getLanguages($http_accept_language, $resolution = 100)
     {
-        $tags = array_filter(array_map('self::parse', explode(',', $http_accept_language)));
+        $tags = array_filter(array_map(self::class . '::parse', explode(',', $http_accept_language)));
 
         $grouped_tags = array();
         foreach ($tags as $tag) {


### PR DESCRIPTION
Hello,

I fixed `Use of "self" in callables is deprecated` warning on PHP 8.2.

Regards,
